### PR TITLE
Add support for Perl::Critic configuration profiles

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Git-Critic
 
 {{$NEXT}}
 
+0.6       2022-01-25 16:36:24
+
+          - Added support for Perl::Critic configuration profiles.
+
 0.4       2022-01-23 11:56:48 CET
 
           - Bugfix: use `git show $target:$file` to get file contents to write to a

--- a/bin/git-perl-critic
+++ b/bin/git-perl-critic
@@ -16,6 +16,7 @@ GetOptions(
     "against=s",          # branch you're critiquing against
     "critique=s",         # non-primary branch to critique
     "severity=s",         # Perl::Critic severity (default: 5, gentle)
+    "profile=s",          # Perl::Critic profile filepath
     "max_file_size=i",    # maximum file size of Perl modules to parse
     "help|?",             # show brief help
     "man",                # show full help
@@ -48,6 +49,7 @@ my $primary = shift @ARGV;
 
 # munge options
 $opt_for{severity} ||= 5;
+$opt_for{profile}  ||= '';
 $opt_for{verbose}  ||= 0;
 
 pod2usage( -verbose => 1 ) if ( $opt_for{help} );

--- a/bin/git-perl-critic
+++ b/bin/git-perl-critic
@@ -55,7 +55,7 @@ $opt_for{verbose}  ||= 0;
 pod2usage( -verbose => 1 ) if ( $opt_for{help} );
 pod2usage( -verbose => 2 ) if ( $opt_for{man} );
 
-our $VERSION = '0.5';
+our $VERSION = '0.6';
 use Git::Critic;
 my $critic = Git::Critic->new(
     primary_target => $primary,

--- a/lib/Git/Critic.pm
+++ b/lib/Git/Critic.pm
@@ -14,7 +14,7 @@ use List::Util qw(uniq);
 use Moo;
 use Types::Standard qw( ArrayRef Bool Int Str);
 
-our $VERSION = '0.5';
+our $VERSION = '0.6';
 
 #
 # Moo attributes

--- a/lib/Git/Critic.pm
+++ b/lib/Git/Critic.pm
@@ -45,6 +45,12 @@ has severity => (
     default => 5,
 );
 
+has profile => (
+    is      => 'ro',
+    isa     => Str,
+    default => '',
+);
+
 has verbose => (
     is      => 'ro',
     isa     => Bool,
@@ -194,9 +200,12 @@ sub run {
         print $fh $file_text;
         close $fh;
         my $severity = $self->severity;
+        my $profile = $self->profile;
+        my @arguments = ("--severity=$severity");
+        push @arguments, "--profile=$profile" if $profile;
+        push @arguments, $filename;
         my $critique =
-          $self->_run_without_die( 'perlcritic', "--severity=$severity",
-            $filename );
+          $self->_run_without_die( 'perlcritic', @arguments );
         next FILE unless $critique; # should never happen unless perlcritic dies
         my @critiques = split /\n/, $critique;
 
@@ -319,6 +328,12 @@ default severity level is "gentle" (5).
     -severity => 'harsh'                      -severity => 3
     -severity => 'cruel'                      -severity => 2
     -severity => 'brutal'                     -severity => 1
+
+=head2 C<profile>
+
+Optional.
+
+This is a filepath to a C<Perl::Critic> configuration file.
 
 =head2 C<verbose>
 


### PR DESCRIPTION
This pull request adds support for [`Perl::Critic` profile files](https://metacpan.org/pod/Perl::Critic#CONFIGURATION).