### PR TITLE
Diff only files changed on the branch

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Git-Critic
 
-{{$NEXT}}
+{{$NEXT}} 2022-02-08 13:59:00 UTC
+
+          - Use triple-dot git diff command to see only changes on the target branch
 
 0.4       2022-01-23 11:56:48 CET
 

--- a/lib/Git/Critic.pm
+++ b/lib/Git/Critic.pm
@@ -133,7 +133,7 @@ sub _get_modified_perl_files {
     my $current_target = $self->current_target;
     my @files          = uniq sort grep { /\S/ && $self->_is_perl($_) }
       split /\n/ => $self->_run( 'git', 'diff', '--name-only',
-        "$primary_target..$current_target" );
+        "$primary_target...$current_target" );
     return @files;
 }
 
@@ -144,7 +144,7 @@ sub _get_diff {
     my $current_target = $self->current_target;
     my @diff =
       split /\n/ =>
-      $self->_run( 'git', 'diff', "$primary_target..$current_target", $file );
+      $self->_run( 'git', 'diff', "$primary_target...$current_target", $file );
     return @diff;
 }
 


### PR DESCRIPTION
Changing `git diff primary..current` to `git diff primary...current`
(i.e. three dots instead of two) shows only diff caused by
commits on the "current" branch, rather than including
diffs caused by changes made on the "primary" branch since
"current" was cut from it.

Because of the way diffs are parsed, this only shows errors when
something else is wrong (misconfiguration/other bug) but
still seems like what we should be doing and cuts down on work.