### PR TITLE
Avoid suppressing multiple instances of errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Git-Critic
 
-{{$NEXT}}
+{{$NEXT}} 2022-02-08 13:57:29 UTC
+
+          - Bugfix: initialised `%reported` hash once per file to avoid suppressing multiple errors
 
 0.4       2022-01-23 11:56:48 CET
 

--- a/lib/Git/Critic.pm
+++ b/lib/Git/Critic.pm
@@ -178,9 +178,10 @@ sub run {
     # figure out the start and end of every change you've made. Any perlcritic
     # failures which are *not* on those lines are ignored
     my @files = $self->_get_modified_perl_files;
-    my %reported;
     my @failures;
   FILE: foreach my $file (@files) {
+        my %reported;
+
         my $file_text = $self->_run( 'git', 'show', "${current_target}:$file" )
           or next FILE;
         if ( $self->max_file_size ) {


### PR DESCRIPTION
Initialise %reported per file because it was previously only reporting
one instance of a given error across all files.